### PR TITLE
Multiline code bad formatted

### DIFF
--- a/assets/javascripts/discourse/initializers/cfbtn.js.es6
+++ b/assets/javascripts/discourse/initializers/cfbtn.js.es6
@@ -10,7 +10,7 @@ function addButtons(siteSettings) {
           id: "cfbtn_openhab_items",
           group: "extras",
           icon: "file-text-o",
-          perform: e => e.applySurround('\n```csv\n', '\n```\n', 'cfbtn_code_default_text')
+          perform: e => e.applySurround('\n```csv\n', '\n```\n', 'cfbtn_code_default_text', { multiline: false } )
         });
       });
     }
@@ -21,7 +21,7 @@ function addButtons(siteSettings) {
           id: "cfbtn_openhab_rules",
           group: "extras",
           icon: "file-code-o",
-          perform: e => e.applySurround('\n```php\n', '\n```\n', 'cfbtn_code_default_text')
+          perform: e => e.applySurround('\n```php\n', '\n```\n', 'cfbtn_code_default_text', { multiline: false } )
         });
       });
     }
@@ -32,7 +32,7 @@ function addButtons(siteSettings) {
           id: "cfbtn_openhab_sitemap",
           group: "extras",
           icon: "file-image-o",
-          perform: e => e.applySurround('\n```php\n', '\n```\n', 'cfbtn_code_default_text')
+          perform: e => e.applySurround('\n```php\n', '\n```\n', 'cfbtn_code_default_text', { multiline: false } )
         });
       });
     }
@@ -43,7 +43,7 @@ function addButtons(siteSettings) {
           id: "cfbtn_javascript",
           group: "extras",
           icon: "file-code-o",
-          perform: e => e.applySurround('\n```javascript\n', '\n```\n', 'cfbtn_code_default_text')
+          perform: e => e.applySurround('\n```javascript\n', '\n```\n', 'cfbtn_code_default_text', { multiline: false } )
         });
       });
     }
@@ -55,7 +55,7 @@ function addButtons(siteSettings) {
           id: ("cfbtn_custom1"),
           group: "extras",
           icon: "file-code-o",
-          perform: e => e.applySurround('\n```' + syntax + '\n', '\n```\n', 'cfbtn_code_default_text')
+          perform: e => e.applySurround('\n```' + syntax + '\n', '\n```\n', 'cfbtn_code_default_text', { multiline: false } )
         });
       });
     }

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # name: Toolbar Code Fences Buttons (cfbtn)
 # about: Add additional buttons for language-specific code fences to the composer toolbar
 #        https://meta.discourse.org/t/syntax-highlighting-of-code-blocks
-# version: 0.4.0
+# version: 0.5.0
 # authors: Thomas Dietrich
 # url: https://github.com/ThomDietrich/discourse-plugin-code-fences-buttons
 


### PR DESCRIPTION
Apply patch for better usability when code is marked and the code fence is applied by pressing the buttons.

Fixe taken from:
https://github.com/discourse/discourse-spoiler-alert/blob/5ef1aa84834f239be89c61a76f467179f9096bd4/assets/javascripts/initializers/spoiler-alert.js.es6#L26

Signed-off-by: josar josuaarndt@live.de