### PR TITLE
According to the docs icons should be registered

### DIFF
--- a/assets/javascripts/discourse/initializers/cfbtn.js.es6
+++ b/assets/javascripts/discourse/initializers/cfbtn.js.es6
@@ -9,7 +9,7 @@ function addButtons(siteSettings) {
         toolbar.addButton({
           id: "cfbtn_openhab_items",
           group: "extras",
-          icon: "file-text-o",
+          icon: "far-file-text-o",
           perform: e => e.applySurround('\n```csv\n', '\n```\n', 'cfbtn_code_default_text', { multiline: false } )
         });
       });
@@ -20,7 +20,7 @@ function addButtons(siteSettings) {
         toolbar.addButton({
           id: "cfbtn_openhab_rules",
           group: "extras",
-          icon: "file-code-o",
+          icon: "far-file-code-o",
           perform: e => e.applySurround('\n```php\n', '\n```\n', 'cfbtn_code_default_text', { multiline: false } )
         });
       });
@@ -31,7 +31,7 @@ function addButtons(siteSettings) {
         toolbar.addButton({
           id: "cfbtn_openhab_sitemap",
           group: "extras",
-          icon: "fa-file-image",
+          icon: "far-file-image",
           perform: e => e.applySurround('\n```php\n', '\n```\n', 'cfbtn_code_default_text', { multiline: false } )
         });
       });
@@ -42,7 +42,7 @@ function addButtons(siteSettings) {
         toolbar.addButton({
           id: "cfbtn_javascript",
           group: "extras",
-          icon: "fa-file-code-o",
+          icon: "far-file-code",
           perform: e => e.applySurround('\n```javascript\n', '\n```\n', 'cfbtn_code_default_text', { multiline: false } )
         });
       });
@@ -54,7 +54,7 @@ function addButtons(siteSettings) {
         toolbar.addButton({
           id: ("cfbtn_custom1"),
           group: "extras",
-          icon: "fa-file-code-o",
+          icon: "far-file-code",
           perform: e => e.applySurround('\n```' + syntax + '\n', '\n```\n', 'cfbtn_code_default_text', { multiline: false } )
         });
       });

--- a/assets/javascripts/discourse/initializers/cfbtn.js.es6
+++ b/assets/javascripts/discourse/initializers/cfbtn.js.es6
@@ -9,7 +9,7 @@ function addButtons(siteSettings) {
         toolbar.addButton({
           id: "cfbtn_openhab_items",
           group: "extras",
-          icon: "far-file-text-o",
+          icon: "far-file-text",
           perform: e => e.applySurround('\n```csv\n', '\n```\n', 'cfbtn_code_default_text', { multiline: false } )
         });
       });
@@ -20,7 +20,7 @@ function addButtons(siteSettings) {
         toolbar.addButton({
           id: "cfbtn_openhab_rules",
           group: "extras",
-          icon: "far-file-code-o",
+          icon: "far-file-code",
           perform: e => e.applySurround('\n```php\n', '\n```\n', 'cfbtn_code_default_text', { multiline: false } )
         });
       });

--- a/assets/javascripts/discourse/initializers/cfbtn.js.es6
+++ b/assets/javascripts/discourse/initializers/cfbtn.js.es6
@@ -9,7 +9,7 @@ function addButtons(siteSettings) {
         toolbar.addButton({
           id: "cfbtn_openhab_items",
           group: "extras",
-          icon: "far-file-text",
+          icon: "far-file-alt",
           perform: e => e.applySurround('\n```csv\n', '\n```\n', 'cfbtn_code_default_text', { multiline: false } )
         });
       });

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # name: Toolbar Code Fences Buttons (cfbtn)
 # about: Add additional buttons for language-specific code fences to the composer toolbar
 #        https://meta.discourse.org/t/syntax-highlighting-of-code-blocks
-# version: 0.6.0
+# version: 0.7.0
 # authors: Thomas Dietrich
 # url: https://github.com/ThomDietrich/discourse-plugin-code-fences-buttons
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -6,3 +6,7 @@
 # url: https://github.com/ThomDietrich/discourse-plugin-code-fences-buttons
 
 enabled_site_setting :cfbtn_enabled
+
+register_svg_icon "fa-file-text-o" if respond_to?(:register_svg_icon)
+register_svg_icon "fa-file-code-o" if respond_to?(:register_svg_icon)
+register_svg_icon "fa-file-image-o" if respond_to?(:register_svg_icon)

--- a/plugin.rb
+++ b/plugin.rb
@@ -7,6 +7,6 @@
 
 enabled_site_setting :cfbtn_enabled
 
-register_svg_icon "fa-file-text-o" if respond_to?(:register_svg_icon)
-register_svg_icon "fa-file-code-o" if respond_to?(:register_svg_icon)
-register_svg_icon "fa-file-image-o" if respond_to?(:register_svg_icon)
+register_svg_icon "far-file-text" if respond_to?(:register_svg_icon)
+register_svg_icon "far-file-code" if respond_to?(:register_svg_icon)
+register_svg_icon "far-file-image" if respond_to?(:register_svg_icon)

--- a/plugin.rb
+++ b/plugin.rb
@@ -7,6 +7,6 @@
 
 enabled_site_setting :cfbtn_enabled
 
-register_svg_icon "far-file-text" if respond_to?(:register_svg_icon)
+register_svg_icon "far-file-alt" if respond_to?(:register_svg_icon)
 register_svg_icon "far-file-code" if respond_to?(:register_svg_icon)
 register_svg_icon "far-file-image" if respond_to?(:register_svg_icon)

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # name: Toolbar Code Fences Buttons (cfbtn)
 # about: Add additional buttons for language-specific code fences to the composer toolbar
 #        https://meta.discourse.org/t/syntax-highlighting-of-code-blocks
-# version: 0.5.0
+# version: 0.6.0
 # authors: Thomas Dietrich
 # url: https://github.com/ThomDietrich/discourse-plugin-code-fences-buttons
 


### PR DESCRIPTION
I checked the latest version and icons still unavailable.
According to the doc the icons plugin gonna use should be registered
https://meta.discourse.org/t/introducing-font-awesome-5-and-svg-icons/101643